### PR TITLE
Add NFT metadata to Checkout

### DIFF
--- a/frontend/app/components/Checkout.tsx
+++ b/frontend/app/components/Checkout.tsx
@@ -3,10 +3,9 @@ import Text from "./Text";
 import { Contract } from "zksync-web3";
 import usePaymaster from "../hooks/usePaymaster";
 import zkSyncImage from "../assets/zkSync_logo.png";
+import { PowerStoneNft } from "../types/powerStoneNft";
 
 const method = "setGreeting";
-// TODO: update to use NFT metadata
-const nft = { name: "MIND STONE", amount: "FREE" };
 
 type CheckoutProps = {
   greeterInstance: Contract | null;
@@ -15,7 +14,7 @@ type CheckoutProps = {
   cost: string;
   price: string;
   gas: string;
-  hasNFT: boolean;
+  nfts: PowerStoneNft[];
 };
 
 type GreeterData = {
@@ -29,11 +28,17 @@ export default function Checkout({
   cost,
   price,
   gas,
-  hasNFT,
+  nfts,
 }: CheckoutProps) {
   // Updates greeting on the contract
+  const hasNFT = nfts.length > 0;
+
   const updateGreeting = async ({ message }: GreeterData) => {
     try {
+      if (greeterInstance == null) {
+        return;
+      }
+
       let txHandle;
       if (hasNFT) {
         const params = await usePaymaster({ greeterInstance, message, price });
@@ -74,17 +79,6 @@ export default function Checkout({
                 <dt>Transaction: </dt>
                 <dd className="text-gray-900">{method}</dd>
               </div>
-              {hasNFT && (
-                <div className="flex justify-between">
-                  <dt className="flex">
-                    Infinity Stone NFT
-                    <span className="ml-2 rounded-full bg-gray-200 px-2 py-0.5 text-xs tracking-wide text-gray-600">
-                      {nft.name}
-                    </span>
-                  </dt>
-                  <dd className="text-gray-900">{nft.amount}</dd>
-                </div>
-              )}
               <div className="flex justify-between">
                 <dt>Transaction Fee: </dt>
                 <dd className="text-gray-900">{gas} ETH</dd>
@@ -93,24 +87,53 @@ export default function Checkout({
                 <dt>Gas Price: </dt>
                 <dd className="text-gray-900">{price} ETH</dd>
               </div>
-              <div className="flex items-center justify-between border-t border-gray-200 pt-6 text-gray-900">
-                <dt className="text-base">
-                  Total Cost{" "}
-                  {hasNFT ? (
-                    <span className="text-emerald-500">SAVED:</span>
-                  ) : (
-                    ":"
-                  )}
-                </dt>
-                <dd className="text-base">{cost} ETH</dd>
-              </div>
+              {!hasNFT && (
+                <div className="flex items-center justify-between border-t border-gray-200 pt-6 text-gray-900">
+                  <dt className="text-base">
+                    Total Cost:
+                  </dt>
+                  <dd className="text-base">{cost} ETH</dd>
+                </div>
+              )}
+              {hasNFT && (
+                <>
+                  {/* Just choose the first stone if the wallet has more than one */}
+                  <div className="flex items-center justify-between border-t border-gray-200 pt-6 text-gray-900">
+                    <dt>
+                      Estimated Cost:
+                    </dt>
+                    <dd className="text-base">{cost} ETH</dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="flex items-center">
+                      NFT Discount
+                      <span
+                        className="ml-2 rounded-full bg-gray-200 px-2 py-0.5 text-xs tracking-wide text-white h-5"
+                        style={{
+                          backgroundColor: nfts[0].attributes.find(x => x.trait_type === "Color")?.value,
+                          // Do not display white font on a yellow background, it should be black for readability
+                          color: nfts[0].attributes.find(x => x.trait_type === "Color")?.value === "Yellow" ? "black" : "white",
+                        }}>
+                        {nfts[0].name}
+                      </span>
+                    </dt>
+                    <dd className="flex items-center text-emerald-500 font-bold">-100%</dd>
+                  </div>
+                  <div className="flex items-center justify-between border-t border-gray-200 pt-6 text-gray-900">
+                    <dt className="text-base">
+                      Total Cost:
+                    </dt>
+                    <dd className="text-base">FREE</dd>
+                  </div>
+                </>
+              )}
             </dl>
             <button
               type="submit"
               onClick={() => updateGreeting({ message })}
               className="mt-6 w-full rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
             >
-              Change Greeting {hasNFT ? "FREE" : cost + " ETH"}
+              Change Greeting for {hasNFT ? "FREE" : cost + " ETH"}
             </button>
           </div>
         </section>
@@ -119,17 +142,22 @@ export default function Checkout({
         <section className="flex-auto overflow-y-auto px-4 pb-16 pt-12 sm:px-6 sm:pt-16 lg:px-8 lg:pb-24 lg:pt-0 bg-white justify-between">
           <div className="mx-auto max-w-lg mt-12">
             {hasNFT ? (
-              <Text>
-                Congratulations! You own an Infinity Stone NFT. Enjoy gas-free
-                transactions, courtesy of Stark Industries Paymaster.
-              </Text>
+              <div className="flex flex-col items-center">
+                <Text>
+                  Congratulations! You own an Infinity Stone NFT. Enjoy gas-free
+                  transactions, courtesy of Stark Industries Paymaster.
+                </Text>
+                <img
+                  className="h-36"
+                  src={nfts[0].image}
+                  alt="Power Stone Image" />
+              </div>
             ) : (
               <Text>
                 Unfortunately, you don't own an Infinity Stone NFT. A small gas
                 fee will be charged to update the greeting.
               </Text>
             )}
-            {/* // TODO: this will be NFT Image  */}
             <div className="mb-8 mt-8">
               <Image
                 src={zkSyncImage}

--- a/frontend/app/components/Input.tsx
+++ b/frontend/app/components/Input.tsx
@@ -4,19 +4,20 @@ import React, { useState, useEffect } from "react";
 import { Web3Provider, Contract } from "zksync-web3";
 import Modal from "./Modal";
 import * as ethers from "ethers";
+import { PowerStoneNft } from "../types/powerStoneNft";
 
 type InputProps = {
   greeterInstance: Contract | null;
   setGreetingMessage: React.Dispatch<React.SetStateAction<string>>;
   provider: Web3Provider | null;
-  hasNFT: boolean;
+  nfts: PowerStoneNft[];
 };
 
 export default function Input({
   greeterInstance,
   setGreetingMessage,
   provider,
-  hasNFT,
+  nfts,
 }: InputProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [message, setMessage] = useState("");
@@ -90,7 +91,7 @@ export default function Input({
           cost={cost}
           price={price}
           gas={gas}
-          hasNFT={hasNFT}
+          nfts={nfts}
         />
       )}
     </div>

--- a/frontend/app/components/Modal.tsx
+++ b/frontend/app/components/Modal.tsx
@@ -5,6 +5,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { Contract } from "zksync-web3";
 import Checkout from "./Checkout";
+import { PowerStoneNft } from "../types/powerStoneNft";
 
 type ModalProps = {
     closeModal: () => void;
@@ -14,15 +15,24 @@ type ModalProps = {
     cost: string;
     price: string;
     gas: string;
-    hasNFT: boolean;
+    nfts: PowerStoneNft[];
 };
 
-export default function Modal({ greeterInstance, message, setGreetingMessage, cost, price, gas, hasNFT }: ModalProps) {
+export default function Modal({
+  closeModal,
+  greeterInstance,
+  message,
+  setGreetingMessage,
+  cost,
+  price,
+  gas,
+  nfts
+}: ModalProps) {
   const [open, setOpen] = useState(true);
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={setOpen}>
+      <Dialog as="div" className="relative z-10" onClose={closeModal}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"
@@ -58,7 +68,14 @@ export default function Modal({ greeterInstance, message, setGreetingMessage, co
                   </button>
                 </div>
                 <div className="sm:flex sm:items-start">
-                  <Checkout greeterInstance={greeterInstance} message={message} setGreetingMessage={setGreetingMessage} cost={cost} price={price} gas={gas} hasNFT={hasNFT} />
+                  <Checkout
+                    greeterInstance={greeterInstance}
+                    message={message}
+                    setGreetingMessage={setGreetingMessage}
+                    cost={cost}
+                    price={price}
+                    gas={gas}
+                    nfts={nfts} />
                 </div>
               </Dialog.Panel>
             </Transition.Child>

--- a/frontend/app/types/powerStoneNft.d.ts
+++ b/frontend/app/types/powerStoneNft.d.ts
@@ -1,0 +1,11 @@
+export interface PowerStoneNft {
+    attributes: PowerStoneAttributes[];
+    description: string;
+    image: string;
+    name: string;
+}
+
+export interface PowerStoneAttributes {
+    trait_type: string;
+    value: string;
+}

--- a/zksync/README.md
+++ b/zksync/README.md
@@ -13,7 +13,6 @@ This project was scaffolded with [zksync-cli](https://github.com/matter-labs/zks
 
 - `yarn hardhat compile` will compile the contracts.
 - `yarn run deploy` will execute the deployment script `/deploy/deploy-greeter.ts`. Requires [environment variable setup](#environment-variables).
-- `yarn run greet` will execute the script `/deploy/use-greeter.ts` which interacts with the Greeter contract deployed.
 - `yarn test`: run tests. **Check test requirements below.**
 
 Both `yarn run deploy` and `yarn run greet` are configured in the `package.json` file and run `yarn hardhat deploy-zksync`.

--- a/zksync/contracts/ERC721.sol
+++ b/zksync/contracts/ERC721.sol
@@ -45,6 +45,8 @@ contract InfinityStones is ERC721URIStorage, Ownable {
 
     function tokenURI(uint256 _tokenId) public view override returns (string memory) {
         require(_exists(_tokenId), "ERC721URIStorage: URI query for nonexistent token");
+        // TODO: Return the correct IPFS ID given the name of the token
+        // Ex: 'Power Stone' -> 0, 'Mind Stone' -> 1, etc.
         return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, "/", Strings.toString(_tokenId))) : "";
     }
 

--- a/zksync/deploy/deploy-ERC721.ts
+++ b/zksync/deploy/deploy-ERC721.ts
@@ -66,10 +66,16 @@ export default async function (hre: HardhatRuntimeEnvironment) {
   // Mint NFTs to the recipient address
   const tx = await nftContract.mint(RECIPIENT_ADDRESS, stone);
   await tx.wait();
+  console.log(`The ${stone} has been given to ${RECIPIENT_ADDRESS}`);
 
   // Get and log the balance of the recipient
   const balance = await nftContract.balanceOf(RECIPIENT_ADDRESS);
   console.log(`Balance of the recipient: ${balance}`);
+
+  // Update base URI
+  let setBaseUriTransaction = await nftContract.setBaseURI("https://ipfs.io/ipfs/QmPtDtJEJDzxthbKmdgvYcLa9oNUUUkh7vvz5imJFPQdKx");
+  await setBaseUriTransaction.wait();
+  console.log(`New baseURI is ${await nftContract.baseURI()}`);
 
   // Verify contract programmatically
   //


### PR DESCRIPTION
# What :computer: 
* Add NFT metadata/image to checkout modal
* Update checkout modal with NFT to show the 100% discount
* Fix bug where closing the modal put the page in a bad state
* Update the deployments scripts to configure the base URI of the NFT contract
* Remove reference to `yarn run greet` command in the README

# Why :hand:
* To complete the `TODO` of this repo and provide a visual that the user has a Power Stone
* It feels easier to understand that having this special NFT is a discount when it's treated like a Discount Code at the very bottom of the checkout. This way, you clearly see the total is `FREE` at the bottom
* Without this fix, closing the modal didn't allow the user to re-open without fully refreshing the page (which is frustrating)
* The base URI is required for the metadata of the stones
* The `greet` yarn command was removed a while ago, so no need to reference it in the README

# Evidence :camera:
A user with one of the Power Stones at checkout:
<img width="1043" alt="image" src="https://github.com/dutterbutter/nft-paymaster-dapp/assets/1890113/a9366f3f-e19a-4108-91c5-9f84fe93e81b">

A user without one of the Power Stones at checkout:
<img width="1044" alt="image" src="https://github.com/dutterbutter/nft-paymaster-dapp/assets/1890113/be9c836c-413f-41b7-830d-8ee94a7f330e">


# Notes :memo:
* The IPFS Path returned from the NFT contract is always setting the ID to `0`. This is inaccurate as the first stone in the list to be distributed is not always the "Power Stone". Added a `TODO:` in the code accordingly (it also requires an update to IPFS to push the other JSON files)
* Even though all Power Stones associated with the user are available as an Array within the Checkout modal, I choose the first one to make the UI simpler (I felt that showing multiple lines of a `100%` discount could be confusing)